### PR TITLE
Add onedark theme

### DIFF
--- a/onedark.vifm
+++ b/onedark.vifm
@@ -1,0 +1,30 @@
+" gruvbox color scheme approximation for vifm
+
+" Reset all styles first
+highlight clear
+
+highlight Border	cterm=none	ctermfg=035	ctermbg=015
+
+highlight TopLine	cterm=none	ctermfg=002	ctermbg=015
+highlight TopLineSel	cterm=bold	ctermfg=002	ctermbg=015
+
+highlight Win		cterm=none	ctermfg=250	ctermbg=default
+"highlight OtherWin  cterm=none	ctermfg=223	ctermbg=236
+highlight Directory	cterm=bold	ctermfg=004	ctermbg=default
+highlight CurrLine	cterm=bold,inverse	ctermfg=default	ctermbg=default
+highlight OtherLine	cterm=bold	ctermfg=default	ctermbg=default
+highlight Selected	cterm=none	ctermfg=003	ctermbg=008
+
+highlight JobLine	cterm=bold	ctermfg=116	ctermbg=238
+highlight StatusLine	cterm=bold	ctermfg=002	ctermbg=015
+highlight ErrorMsg	cterm=bold	ctermfg=001	ctermbg=default
+highlight WildMenu	cterm=bold	ctermfg=015	ctermbg=002
+highlight CmdLine	cterm=none	ctermfg=007	ctermbg=default
+
+highlight Executable	cterm=bold	ctermfg=002	ctermbg=default
+highlight Link		cterm=bold	ctermfg=006	ctermbg=default
+highlight BrokenLink	cterm=bold	ctermfg=001	ctermbg=default
+highlight Device	cterm=bold,standout	ctermfg=000	ctermbg=011
+highlight Fifo		cterm=none	ctermfg=003	ctermbg=default
+highlight Socket	cterm=bold	ctermfg=005	ctermbg=default
+

--- a/onedark.vifm
+++ b/onedark.vifm
@@ -3,9 +3,9 @@
 " Reset all styles first
 highlight clear
 
-highlight Border	cterm=none	ctermfg=035	ctermbg=015
+highlight Border	cterm=none	ctermfg=035	ctermbg=default
 
-highlight TopLine	cterm=none	ctermfg=002	ctermbg=015
+highlight TopLine	cterm=none	ctermfg=002	ctermbg=default
 highlight TopLineSel	cterm=bold	ctermfg=002	ctermbg=015
 
 highlight Win		cterm=none	ctermfg=250	ctermbg=default

--- a/onedark.vifm
+++ b/onedark.vifm
@@ -15,9 +15,9 @@ highlight OtherLine	cterm=bold	ctermfg=default	ctermbg=default
 highlight Selected	cterm=none	ctermfg=003	ctermbg=008
 
 highlight JobLine	cterm=bold	ctermfg=116	ctermbg=238
-highlight StatusLine	cterm=bold	ctermfg=002	ctermbg=015
+highlight StatusLine	cterm=none	ctermfg=250	ctermbg=015
 highlight ErrorMsg	cterm=bold	ctermfg=001	ctermbg=default
-highlight WildMenu	cterm=bold	ctermfg=015	ctermbg=002
+highlight WildMenu	cterm=bold	ctermfg=015	ctermbg=250
 highlight CmdLine	cterm=none	ctermfg=007	ctermbg=default
 
 highlight Executable	cterm=bold	ctermfg=002	ctermbg=default

--- a/onedark.vifm
+++ b/onedark.vifm
@@ -1,4 +1,4 @@
-" gruvbox color scheme approximation for vifm
+" onedark color scheme for vifm
 
 " Reset all styles first
 highlight clear
@@ -9,7 +9,6 @@ highlight TopLine	cterm=none	ctermfg=002	ctermbg=015
 highlight TopLineSel	cterm=bold	ctermfg=002	ctermbg=015
 
 highlight Win		cterm=none	ctermfg=250	ctermbg=default
-"highlight OtherWin  cterm=none	ctermfg=223	ctermbg=236
 highlight Directory	cterm=bold	ctermfg=004	ctermbg=default
 highlight CurrLine	cterm=bold,inverse	ctermfg=default	ctermbg=default
 highlight OtherLine	cterm=bold	ctermfg=default	ctermbg=default

--- a/onedark.vifm
+++ b/onedark.vifm
@@ -14,7 +14,7 @@ highlight CurrLine	cterm=bold,inverse	ctermfg=default	ctermbg=default
 highlight OtherLine	cterm=bold	ctermfg=default	ctermbg=default
 highlight Selected	cterm=none	ctermfg=003	ctermbg=008
 
-highlight JobLine	cterm=bold	ctermfg=116	ctermbg=238
+highlight JobLine	cterm=bold	ctermfg=250	ctermbg=008
 highlight StatusLine	cterm=none	ctermfg=250	ctermbg=015
 highlight ErrorMsg	cterm=bold	ctermfg=001	ctermbg=default
 highlight WildMenu	cterm=bold	ctermfg=015	ctermbg=250


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19517248/77227983-6efab280-6b84-11ea-8b99-4a249366473d.png)

Relies on the following terminal 16-color palette:
```
colors:
  # Default colors
  primary:
    background: '0x282C34'
    foreground: '0xABB2BF'
  # Normal colors
  normal:
    black:   '0x5C6370'
    red:     '0xE06C75'
    green:   '0x98C379'
    yellow:  '0xE5C07B'
    blue:    '0x61AFEF'
    magenta: '0xC678DD'
    cyan:    '0x56B6C2'
    white:   '0xABB2BF'
  # Bright colors
  bright:
    black:   '0x4B5263'
    red:     '0xBE5046'
    green:   '0x98C379'
    yellow:  '0xD19A66'
    blue:    '0x61AFEF'
    magenta: '0xC678DD'
    cyan:    '0x56B6C2'
    white:   '0x3E4452'
```
 I used the `gruvbox` theme as template.

