### PR TITLE
improved solarized dark theme

### DIFF
--- a/solarized-dark.vifm
+++ b/solarized-dark.vifm
@@ -19,7 +19,6 @@
 " standout
 " none
 
-
 highlight clear
 
 highlight Win             cterm=none ctermfg=default    ctermbg=none
@@ -29,14 +28,14 @@ highlight TopLineSel      cterm=none ctermfg=blue       ctermbg=none
 highlight StatusLine      cterm=none ctermfg=blue       ctermbg=none
 highlight Border          cterm=none ctermfg=blue       ctermbg=none
 
-highlight Selected        cterm=bold ctermfg=magenta    ctermbg=default
-highlight CurrLine        cterm=bold ctermfg=default    ctermbg=blue
+highlight Selected        cterm=bold ctermfg=green       ctermbg=none
+highlight CurrLine        cterm=bold,reverse ctermfg=default    ctermbg=default
 
 highlight WildMenu        cterm=underline,reverse ctermfg=white ctermbg=black
 highlight CmdLine         cterm=none ctermfg=white ctermbg=black
 highlight ErrorMsg        cterm=none ctermfg=red ctermbg=black
 
-highlight Directory       cterm=none ctermfg=cyan ctermbg=default
+highlight Directory       cterm=bold ctermfg=blue ctermbg=default
 highlight Link            cterm=none ctermfg=yellow ctermbg=default
 highlight BrokenLink      cterm=none ctermfg=red ctermbg=default
 highlight Socket          cterm=none ctermfg=magenta ctermbg=default


### PR DESCRIPTION
I would like to propose a slight modification of the `solarized-dark.vifm` theme that sits better with the classic terminal solarized colour compositions. It can either overwrite the current one or create a second version of it (naming must however be adapted).

Of course feel free to close if you deem it unnecessary.

**Comparison:**

New:
<img width="1366" alt="Screenshot 2021-06-22 at 00 13 30" src="https://user-images.githubusercontent.com/15387611/122835143-22a2a300-d2f0-11eb-970d-4089fdc44ba7.png">

Old:
<img width="1390" alt="Screenshot 2021-06-22 at 00 13 44" src="https://user-images.githubusercontent.com/15387611/122835151-2504fd00-d2f0-11eb-8dc5-14d5afbf9c64.png">
